### PR TITLE
Update derby to version 10.14.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.10.2.0</version>
+      <version>10.14.2.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request solves some security issues. Version 10.14.2.0 is the highest version which still supports Java 8.
Related to #13.